### PR TITLE
Adds pre-commit configuration

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -5,5 +5,5 @@
     language: rust
     'types': [text]
     args: []
-    require_serial: false
+    require_serial: true
     minimum_pre_commit_version: '0'

--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,9 @@
+-   id: secrets
+    name: secrets
+    description: 'Prevent committing secret keys into your source code'
+    entry: secrets
+    language: rust
+    'types': [text]
+    args: []
+    require_serial: false
+    minimum_pre_commit_version: '0'

--- a/README.md
+++ b/README.md
@@ -44,6 +44,24 @@ $ secrets --install-pre-commit
 
 You can download a prebuilt binary for the latest release from the [releases](https://github.com/sirwart/secrets/releases) page.
 
+### Using pre-commit
+
+`secrets` can work as a plugin for [pre-commit](https://pre-commit.com/) with
+the following configuration.
+
+Note that this may require having Cargo and a Rust compiler already installed.
+See the [pre-commit rust plugin docs](https://pre-commit.com/#rust) for more
+information.
+
+```yaml
+repos:
+-   repo: https://github.com/sirwart/secrets.git
+    # Set a specific version or branch instead of the default branch (main)
+    # rev: v0.1.2
+    hooks:
+    -   id: secrets
+```
+
 ## Ignoring secrets
 
 `secrets` will respect your .gitignore files by default, but there might still be files you want to exclude from being scanned for secrets. To do that you can create a .secretsignore file, which supports similar syntax to a .gitignore file for ignoring files. In addition to excluding files, it also it also supports a `[secrets]` section that allows ignoring individual secrets.

--- a/README.md
+++ b/README.md
@@ -56,8 +56,8 @@ information.
 ```yaml
 repos:
 -   repo: https://github.com/sirwart/secrets.git
-    # Set a specific version or branch instead of the default branch (main)
-    # rev: v0.1.2
+    # Set your version, be sure to use the latest and update regularly or use 'main'
+    rev: v0.1.3
     hooks:
     -   id: secrets
 ```


### PR DESCRIPTION
This enables using the repository with [pre-commit][1].

I tested this with

    pre-commit try-repo https://github.com/colindean/secrets.git secrets --verbose --all-files

And the output:

```
===============================================================================
Using config:
===============================================================================
repos:
-   repo: https://github.com/colindean/secrets.git
    rev: 3fe8bf59a62e00fbbdf7de47f57c32058bd5f2ee
    hooks:
    -   id: secrets
===============================================================================
[INFO] Initializing environment for https://github.com/colindean/secrets.git.
[INFO] Installing environment for https://github.com/colindean/secrets.git.
[INFO] Once installed this environment will be reused.
[INFO] This may take a few minutes...
secrets..................................................................Failed
- hook id: secrets
- duration: 0.07s
- exit code: 1

test/one_per_line/random:1:APP_KEY = "iftkeq2y4qj0nbt"
test/one_per_line/npm:2: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
test/one_per_line/mailchimp:1:343ea45721923ed956e2b38c31db76aa-us30
test/one_per_line/square:1:sq0csp-ABCDEFGHIJK_LMNOPQRSTUVWXYZ-0123456789\\abcd
test/one_per_line/twilio:1:ACxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
test/one_per_line/twilio:2:SKxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx
test/one_per_line/slack:1:xoxp-523423-234243-234233-e039d02840a0b9379c
test/one_per_line/slack:2:https://hooks.slack.com/services/Txxxxxxxx/Bxxxxxxxx/xxxxxxxxxxxxxxxxxxxxxxxx
test/one_per_line/aws:1:secret_access_key = '1W0T1eqNpAk3imtH8mJtkSf2AQ3eNMrPqe3u3Tf6'
test/one_per_line/aws:2:secretAccessKey = "wrmDCcpolP3yg9l7o9dJragXbj2wFFzWgiN5FBZN"
test/one_per_line/aws:3:SECRET_ACCESS_KEY: 2OYzBCp/+N9pUJ3a8JA5lOLYL/iKBFYVlif3pIHl
test/one_per_line/azure:1:AccountKey=lJzRc1YdHaAA2KCNJJ1tkYwF/+mKK6Ygw0NGe170Xu592euJv2wYUtBlV8z+qnlcNQSnIYVTkLWntUO1F8j8rQ==
test/one_per_line/azure:2:client_secret = GN.7Q~4AkLZBNEbz4Jxlm~O5G6SsyFxYg6zNR
test/one_per_line/azure:3:api_key = 2N87Q~4m2Bkq.tjC7pDkGksXPutGkChIGNqYc
test/one_per_line/stripe:1:sk_live_ReTllpYQYfIZu2Jnf2lAPFjD
test/one_per_line/stripe:2:rk_live_5TcWfjKmJgpql9hjpRnwRXbT
test/one_per_line/jwt:1:eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ.SflKxwRJSMeKKF2QT4fwpMeJf36POk6yJV_adQssw5c
test/one_per_line/jwt:2:eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiIxMjM0NTY3ODkwIiwibmFtZSI6IkpvaG4gRG9lIiwiaWF0IjoxNTE2MjM5MDIyfQ
test/one_per_line/sendgrid:1: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
test/one_per_line/github:1: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
test/one/private_key:2:-----BEGIN RSA PRIVATE KEY-----
test/one_per_line/gcp:1:key=AIzaSyCw8XmxlGXVRySZxKiuZhFCALuXbLqqHBI
test/one_per_line/gcp:2:AIzaSyBYvIR5fRdK_ZUw4baMjUanLRTA7iopW-I
test/one_per_line/gcp:3:AIzaSyBsk5f14YtkTQr-hIbMjMOMSXIV2KdZlrU
```

[1]: https://pre-commit.com