### PR TITLE
implements clap, with an opinonated choice of using subcommands

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -23,6 +23,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "autocfg"
+version = "1.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d468802bab17cbc0cc575e9b053f41e72aa36bfa6b7f55e3529ffa43161b97fa"
+
+[[package]]
 name = "base64"
 version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -56,6 +62,45 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "3.1.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3124f3f75ce09e22d1410043e1e24f2ecc44fad3afe4f08408f1f7663d68da2b"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_derive",
+ "clap_lex",
+ "indexmap",
+ "lazy_static",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_derive"
+version = "3.1.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a3aab4734e083b809aaf5794e14e756d1c798d2c69c7f7de7a09a2f5214993c1"
+dependencies = [
+ "heck",
+ "proc-macro-error",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "189ddd3b5d32a70b35e7686054371742a937b0d99128e76dde6340210e966669"
+dependencies = [
+ "os_str_bytes",
+]
 
 [[package]]
 name = "crossbeam-utils"
@@ -198,6 +243,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "hashbrown"
+version = "0.11.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab5ef0d4909ef3724cc8cce6ccc8572c5c817592e9285f5464f8e86f8bd3726e"
+
+[[package]]
+name = "heck"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2540771e65fc8cb83cd6e8a237f70c319bd5c29f78ed1084ba5d50eeac86f7f9"
+
+[[package]]
 name = "hermit-abi"
 version = "0.1.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -222,6 +279,16 @@ dependencies = [
  "thread_local",
  "walkdir",
  "winapi-util",
+]
+
+[[package]]
+name = "indexmap"
+version = "1.8.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0f647032dfaa1f8b6dc29bd3edb7bbef4861b8b8007ebb118d6db284fd59f6ee"
+dependencies = [
+ "autocfg",
+ "hashbrown",
 ]
 
 [[package]]
@@ -314,6 +381,36 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "da32515d9f6e6e489d7bc9d84c71b060db7247dc035bbe44eac88cf87486d8d5"
 
 [[package]]
+name = "os_str_bytes"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e22443d1643a904602595ba1cd8f7d896afe56d26712531c5ff73a15b2fbf64"
+
+[[package]]
+name = "proc-macro-error"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "da25490ff9892aab3fcf7c36f08cfb902dd3e71ca0f9f9517bea02a73a5ce38c"
+dependencies = [
+ "proc-macro-error-attr",
+ "proc-macro2",
+ "quote",
+ "syn",
+ "version_check",
+]
+
+[[package]]
+name = "proc-macro-error-attr"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a1be40180e52ecc98ad80b184934baf3d0d29f979574e439af5a55274b35f869"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "version_check",
+]
+
+[[package]]
 name = "proc-macro2"
 version = "1.0.34"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -391,6 +488,7 @@ dependencies = [
 name = "secrets"
 version = "0.1.2"
 dependencies = [
+ "clap",
  "grep",
  "ignore",
  "memoize",
@@ -432,6 +530,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "strsim"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "73473c0e59e6d5812c5dfe2a064a6444949f089e20eec9a2e5506596494e4623"
+
+[[package]]
 name = "syn"
 version = "1.0.84"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -466,6 +570,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "textwrap"
+version = "0.15.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b1141d4d61095b28419e22cb0bbf02755f5e54e0526f97f1e3d1d160e60885fb"
+
+[[package]]
 name = "thread_local"
 version = "1.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -479,6 +589,12 @@ name = "unicode-xid"
 version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ccb82d61f80a663efe1f787a51b16b5a51e3314d6ac365b08639f52387b33f3"
+
+[[package]]
+name = "version_check"
+version = "0.9.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "49874b5167b65d7193b8aba1567f5c7d93d001cafc34600cee003eda787e483f"
 
 [[package]]
 name = "walkdir"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,3 +13,4 @@ regex = "1.1"
 termcolor = "1.1.2"
 memoize = "0.3.0"
 tempfile = "3.3.0"
+clap = { version = "3.1.10", features = ["derive"] }

--- a/README.md
+++ b/README.md
@@ -14,10 +14,10 @@
 
 ## Usage
 
-By default running `secrets` will recursively search source files in your current directory for secrets.
+By default running `secrets check` will recursively search source files in your current directory for secrets.
 
 ```
-$ secrets
+$ secrets check
 ```
 
 For every secret it finds it will print out the file, line number, and the secret that was found. If it finds any secrets it will exit with a non-zero status code.
@@ -25,19 +25,19 @@ For every secret it finds it will print out the file, line number, and the secre
 You can optionally pass a list of files and directories to search as arguments.
 
 ```
-$ secrets file1 file2 dir1
+$ secrets check file1 file2 dir1
 ```
 
 This most commonly used to search files that are about to be committed to source control for accidentically included secrets. You can install `secrets` as a pre-commit hook automatically in your current git repository using the following command:
 
 ```
-$ secrets --install-pre-commit
+$ secrets precommit
 ```
 
-If you would like to install `secrets` manually you can add the following command to yout `pre-commit` script:
+If you would like to install `secrets` manually you can add the following command to your `pre-commit` script:
 
 ```
-$ secrets --strict-ignore `git diff --cached --name-only --diff-filter=ACM`
+$ secrets check --strict-ignore `git diff --cached --name-only --diff-filter=ACM`
 ```
 
 Passing `--strict-ignore` ensures that your `.secretsignore` file is respected when running secrets as a pre-commit.
@@ -63,11 +63,11 @@ information.
 
 ```yaml
 repos:
--   repo: https://github.com/sirwart/secrets.git
-    # Set your version, be sure to use the latest and update regularly or use 'main'
-    rev: v0.1.3
-    hooks:
-    -   id: secrets
+    - repo: https://github.com/sirwart/secrets.git
+      # Set your version, be sure to use the latest and update regularly or use 'main'
+      rev: v0.1.3
+      hooks:
+          - id: secrets
 ```
 
 ## Ignoring secrets
@@ -110,6 +110,6 @@ Most of the time your pre-commit will be running on a small number of files, so 
 
 Even if `secrets` is not the right tool for you, if you're working on a service that deals with user data you should strongly consider using a secret scanner. Here are some alterative tools worth considering:
 
-- [detect-secrets](https://github.com/Yelp/detect-secrets)
-- [trufflehog](https://github.com/trufflesecurity/trufflehog)
-- [gitleaks](https://github.com/zricethezav/gitleaks)
+-   [detect-secrets](https://github.com/Yelp/detect-secrets)
+-   [trufflehog](https://github.com/trufflesecurity/trufflehog)
+-   [gitleaks](https://github.com/zricethezav/gitleaks)

--- a/README.md
+++ b/README.md
@@ -28,10 +28,10 @@ You can optionally pass a list of files and directories to search as arguments.
 $ secrets check file1 file2 dir1
 ```
 
-This most commonly used to search files that are about to be committed to source control for accidentically included secrets. You can install `secrets` as a pre-commit hook automatically in your current git repository using the following command:
+This most commonly used to search files that are about to be committed to source control for accidentally included secrets. You can install `secrets` as a pre-commit hook automatically in your current git repository using the following command:
 
 ```
-$ secrets precommit
+$ secrets install-pre-commit
 ```
 
 If you would like to install `secrets` manually you can add the following command to your `pre-commit` script:

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,7 +1,7 @@
-use std::env;
+use clap::{Args, Parser, Subcommand};
 use std::error::Error;
-use std::ffi::OsString;
 use std::fmt;
+use std::path::Path;
 use std::path::PathBuf;
 use std::process;
 
@@ -30,80 +30,70 @@ impl fmt::Display for UsageError {
     }
 }
 
-fn main_aux(args: &Vec<OsString>) -> Result<usize, Box<dyn Error>> {
-    let mut match_count: usize = 0;
-
-    if args.len() > 1 && args[1] == "--install-pre-commit" {
-        if args.len() > 2 {
-            return Err(Box::new(UsageError::PreCommit));
-        }
-        pre_commit::install_pre_commit(&PathBuf::from("."))?;
-    } else if args.len() > 1 && args[1] == "--version" {
-        if args.len() > 2 {
-            return Err(Box::new(UsageError::Version));
-        }
-        println!("secrets {}", env!("CARGO_PKG_VERSION"));
-    } else if args.len() > 1 && args[1] == "--help" {
-        if args.len() > 2 {
-            return Err(Box::new(UsageError::Help));
-        }
-        println!("secrets {}
-
-secrets searches files and directories recursively for secret API keys.
+/// Prevent committing secret keys into your source code
+#[derive(Parser)]
+#[clap(
+    version,
+    about,
+    name = "secrets",
+    long_about = "secrets searches files and directories recursively for secret API keys.
 It's primarily designed to be used as a pre-commit to prevent committing
-secrets into version control.
-
-USAGE:
-    secrets [--strict-ignore] [PATH ...]
-    secrets --install-pre-commit
-    secrets --help
-    secrets --version
-
-OPTIONS:
-    --install-pre-commit
-        Installs secrets as part of your git pre-commit hook, creating one if
-        one doesn't already exist.
-
-    --strict-ignore
-        If you pass a path as an argument that's ignored by .secretsignore it
-        will be scanned by default. --strict-ignore will override this
-        behavior and not search the paths passed as arguments that are excluded
-        by the .secretsignore file. This is useful when invoking secrets as a
-        pre-commit.", env!("CARGO_PKG_VERSION"))
-    } else {
-        let mut strict_ignore = false;
-        let mut paths = Vec::new();
-        if args.len() > 1 {
-            let mut start_idx = 1;
-            if args[1] == "--strict-ignore" {
-                strict_ignore = true;
-                start_idx = 2;
-            }
-            for path in &args[start_idx..] {
-                paths.push(PathBuf::from(path));
-            }
-        }
-        if paths.len() == 0 {
-            paths.push(PathBuf::from("."));
-        }
-        match_count = find_secrets::find_secrets(&paths, strict_ignore)?;
-    }
-
-    return Ok(match_count);
+secrets into version control."
+)]
+struct Cli {
+    #[clap(subcommand)]
+    command: Commands,
 }
 
-fn main() {
-    let args: Vec<OsString> = env::args_os().collect();
+#[derive(Subcommand)]
+enum Commands {
+    /// Install `secrets` as a pre-commit hook automatically in your current git repository
+    #[clap(alias = "install-pre-commit")]
+    Precommit {},
 
-    match main_aux(&args) {
-        Err(err) => {
-            eprintln!("{}", err);
-            process::exit(2);
-        }
-        Ok(match_count) => {
-            if match_count > 0 {
-                process::exit(1);
+    /// Check files or directories for secrets
+    #[clap(alias = "check")]
+    Check(CheckRequest),
+}
+
+#[derive(Args)]
+struct CheckRequest {
+    /// If you pass a path as an argument that's ignored by .secretsignore it
+    /// will be scanned by default. --strict-ignore will override this
+    /// behavior and not search the paths passed as arguments that are excluded
+    /// by the .secretsignore file. This is useful when invoking secrets as a
+    /// pre-commit.
+    #[clap(long = "strict-ignore")]
+    strict_ignore: bool,
+
+    /// Source files to check for secrets. Can be files or directories.
+    #[clap(name = "Source files to check", parse(from_os_str))]
+    paths: Vec<PathBuf>,
+}
+
+fn main() -> Result<(), Box<dyn Error>> {
+    let cli = Cli::parse();
+    match &cli.command {
+        Commands::Precommit {} => pre_commit::install_pre_commit(Path::new("."))?,
+        Commands::Check(check_request) => {
+            // I don't love this, but it's the best way I can figure to get it to
+            // check "." if given no paths (an empty vec)...
+            if check_request.paths.is_empty() {
+                match find_secrets::find_secrets(
+                    &[PathBuf::from(".")],
+                    check_request.strict_ignore,
+                )? {
+                    0 => process::exit(2),
+                    _ => process::exit(1),
+                }
+            } else {
+                match find_secrets::find_secrets(&check_request.paths, check_request.strict_ignore)?
+                {
+                    0 => process::exit(2),
+                    _ => process::exit(1),
+                }
             }
         }
-    }
+    };
+    Ok(())
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -23,7 +23,7 @@ impl std::error::Error for UsageError {}
 impl fmt::Display for UsageError {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
         match self {
-            UsageError::PreCommit => write!(f, "Usage: secrets --install-pre-commit"),
+            UsageError::PreCommit => write!(f, "Usage: secrets install-pre-commit"),
             UsageError::Version => write!(f, "Usage: secrets --version"),
             UsageError::Help => write!(f, "Usage: secrets --help"),
         }


### PR DESCRIPTION
Attempt 2 at implemented clap on this project. I found I had to make the rather controversial choice of enforcing use of subcommands, so users will need to run `secrets check file1 file2` now. I don't love it, and if it's not expected I understand. But I do think integrating a argument parser will save some headaches as more command-line options are added. 